### PR TITLE
Adding Cloud 66

### DIFF
--- a/content/sites/cloud 66/index.md
+++ b/content/sites/cloud 66/index.md
@@ -1,0 +1,17 @@
+---
+title: Cloud 66
+homepage: https://www.cloud66.com/frameworks/static-sites/
+description: Deploy and serve any static site on your own cloud account.
+twitter: cloud66
+pricing: https://www.cloud66.com/pricing
+---
+
+Cloud 66 builds and deploys static websites (Jamstack) to your own cloud account.
+
+- Automated SSL certificates.
+- LiveLogs.
+- Preview Deployments.
+- Traffic Rules - a completely new way to control traffic before it reaches your site.
+- Frameworks: Hugo, Gatsby, Jekyll, Next.js, Vue.js, Nuxt.js, Svelte, Middleman, and Docusaurus.
+- Cloud providers: Google Cloud, DigitalOcean, Azure, Linode, and AWS.
+- Pricing update: $1.99 / application per month and $0.095 per GB for outbound traffic. 120 Free Build minutes per month ($0.03 per minute after that). Free unlimited team members. 


### PR DESCRIPTION
Adding Cloud 66, a static website host on your own cloud.